### PR TITLE
Fix proxy error

### DIFF
--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
   end
 
   def add_key_from_key_server
-    if resource[:proxy].empty?
+    if resource[:proxy].nil? or resource[:proxy].empty?
       command = "gpg --keyserver #{resource[:key_server]} --recv-keys #{resource[:key_id]}"
     else
       command = "gpg --keyserver #{resource[:key_server]} --keyserver-options http-proxy=#{resource[:proxy]} --recv-keys #{resource[:key_id]}"


### PR DESCRIPTION
Fix: undefined method `empty?' for nil:NilClass

When in puppet 4 and you don't set proxy.