### PR TITLE
Batch import secret keys to avoid interactive prompt with GnuPG 2.1+

### DIFF
--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
 
   def add_key_from_key_content
     path = create_temporary_file(user_id, resource[:key_content])
-    command = "gpg --import #{path}"
+    command = "gpg --batch --import #{path}"
     begin
       output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)
     rescue Puppet::ExecutionFailure => e
@@ -85,7 +85,7 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
 
   def add_key_at_path
     if File.file?(resource[:key_source])
-      command = "gpg --import #{resource[:key_source]}"
+      command = "gpg --batch --import #{resource[:key_source]}"
       begin
         output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)
       rescue Puppet::ExecutionFailure => e
@@ -100,12 +100,12 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
     uri = URI.parse(URI.escape(resource[:key_source]))
     case uri.scheme
     when /https/
-      command = "wget -O- #{resource[:key_source]} | gpg --import"
+      command = "wget -O- #{resource[:key_source]} | gpg --batch --import"
     when /http/
       command = "gpg --fetch-keys #{resource[:key_source]}"
     when 'puppet'
       path = create_temporary_file user_id, puppet_content
-      command = "gpg --import #{path}"
+      command = "gpg --batch --import #{path}"
     end
     begin
       output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)


### PR DESCRIPTION
GnuPG 2.1 and later prompts for secret key passphrase if --import is not coupled with --batch. The rationale for the changed behavior is described in https://dev.gnupg.org/T2313. This problem affects at least Debian 9 ("stretch") which is bundled with GnuPG 2.1.18.

With this change all --import calls include --batch, so that private keys get imported without user interaction. This did not seem to have any ill effects on older GnuPG versions, such as 1.4.18, which comes in Debian 7 ("wheezy").