### PR TITLE
The executed command is now displayed when failed

### DIFF
--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
     begin
       output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)
     rescue Puppet::ExecutionFailure => e
-      raise Puppet::Error, "Error while importing key #{resource[:key_id]} from #{resource[:key_source]}:\n#{output}}"
+      raise Puppet::Error, "Error while importing key #{resource[:key_id]} from #{resource[:key_source]}:\n#{e}"
     end
   end
 


### PR DESCRIPTION
This commit shows what command has been executed when adding a key fails. This makes debugging network issues easier (especially when dealing with corporate proxies providing self signed certificates).

Current behaviour:
```
Error: /Stage[main]/Main/Node[skrieg-dev]/Gnupg_key[hashicorp]/ensure: change from absent to present failed: Error while importing key 51852D87348FFC4C from https://keybase.io/hashicorp/pgp_keys.asc?fingerprint=91a6e7f85d05c65630bef18951852d87348ffc4c:
}
```

What this PR does:
```
Error: /Stage[main]/Main/Node[skrieg-dev]/Gnupg_key[hashicorp]/ensure: change from absent to present failed: Error while importing key 51852D87348FFC4C from https://keybase.io/hashicorp/pgp_keys.asc?fingerprint=91a6e7f85d05c65630bef18951852d87348ffc4c:
Execution of 'wget -O- https://keybase.io/hashicorp/pgp_keys.asc?fingerprint=91a6e7f85d05c65630bef18951852d87348ffc4c | gpg --import' returned 2:
```