### PR TITLE
Replace deprecated URI.escape

### DIFF
--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -97,7 +97,11 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
   end
 
   def add_key_at_url
-    uri = URI.parse(URI.escape(resource[:key_source]))
+    if URI.const_defined? 'DEFAULT_PARSER'
+      uri = URI.parse(URI::DEFAULT_PARSER.escape(resource[:key_source]))
+    else
+      uri = URI.parse(URI.escape(resource[:key_source]))
+    end
     case uri.scheme
     when /https/
       command = "wget -O- #{resource[:key_source]} | gpg --batch --import"

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -88,7 +88,11 @@ Puppet::Type.newtype(:gnupg_key) do
       break if Puppet::Util.absolute_path?(source)
 
       begin
-        uri = URI.parse(URI.escape(source))
+        if URI.const_defined? 'DEFAULT_PARSER'
+          uri = URI.parse(URI::DEFAULT_PARSER.escape(source))
+        else
+          uri = URI.parse(URI.escape(source))
+        end
       rescue => detail
         raise ArgumentError, "Could not understand source #{source}: #{detail}"
       end
@@ -99,8 +103,14 @@ Puppet::Type.newtype(:gnupg_key) do
     end
 
     munge do |source|
-      if %w{file}.include?(URI.parse(URI.escape(source)).scheme)
-        URI.parse(URI.escape(source)).path
+      if URI.const_defined? 'DEFAULT_PARSER'
+        uri = URI.parse(URI::DEFAULT_PARSER.escape(source))
+      else
+        uri = URI.parse(URI.escape(source))
+      end
+
+      if %w{file}.include?(uri.scheme)
+        uri.path
       else
         source
       end
@@ -113,7 +123,11 @@ Puppet::Type.newtype(:gnupg_key) do
 
     validate do |server|
       if server
-        uri = URI.parse(URI.escape(server))
+        if URI.const_defined? 'DEFAULT_PARSER'
+          uri = URI.parse(URI::DEFAULT_PARSER.escape(server))
+        else
+          uri = URI.parse(URI.escape(server))
+        end
         unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS) ||
             uri.is_a?(URI::LDAP) || %w{hkp}.include?(uri.scheme)
           raise ArgumentError, "Invalid keyserver value #{server}"
@@ -156,7 +170,11 @@ Puppet::Type.newtype(:gnupg_key) do
     
     validate do |value|
       if value
-        uri = URI.parse(URI.escape(value))   
+        if URI.const_defined? 'DEFAULT_PARSER'
+          uri = URI.parse(URI::DEFAULT_PARSER.escape(value))
+        else
+          uri = URI.parse(URI.escape(value))
+        end
         unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS) 
           raise ArgumentError, "Invalid proxy value #{value}"
         end


### PR DESCRIPTION
Trying to fix the following deprecation warnings running Puppet 7.x

```
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:91: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:102: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:91: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:102: warning: URI.escape is obsolete
```

I see that minimum supported version of Puppet listed is currently 3.0.0 which I believe supports Ruby 1.8.7 as a minimum.  This _should_ work with that if that's the case (trying not to rock the boat too much), but `URI::DEFAULT_PARSER` was introduced after Ruby > 1.9 roughly.  Dealer's choice, or open to any other ideas.  Thanks!